### PR TITLE
LT-1160: excluding ratings in exclusion list in OGEL SPIRE response

### DIFF
--- a/src/main/java/uk/gov/bis/lite/ogel/model/OgelCondition.java
+++ b/src/main/java/uk/gov/bis/lite/ogel/model/OgelCondition.java
@@ -10,7 +10,6 @@ public class OgelCondition implements Serializable {
   private List<Rating> ratingList;
   private List<Country> countries;
   private CountryStatus countryStatus;
-  private List<Rating> secondaryRatingList;
 
   public enum CountryStatus {
     INCLUDED, EXCLUDED
@@ -45,33 +44,12 @@ public class OgelCondition implements Serializable {
     if (countryStatus.equals(this.countryStatus)) {
       return countries;
     }
-    return new ArrayList<>();
-  }
-
-  public CountryStatus getCountryStatus() {
-    return countryStatus;
-  }
-
-  public void setCountryStatus(CountryStatus countryStatus) {
-    this.countryStatus = countryStatus;
-  }
-
-  public List<Rating> getSecondaryRatingList() {
-    return secondaryRatingList;
-  }
-
-  public void setSecondaryRatingList(List<Rating> secondaryRatingList) {
-    this.secondaryRatingList = secondaryRatingList;
+    return new ArrayList<>(0);
   }
 
   @Override
   public String toString() {
-    return "OgelCondition{" +
-        "id=" + id +
-        ", ratingList=" + ratingList +
-        ", countries=" + countries +
-        ", countryStatus=" + countryStatus.name() +
-        ", secondaryRatingList=" + secondaryRatingList +
-        '}';
+    return String.format("OgelCondition{id=%d, ratingList=%s, countries=%s, countryStatus=%s}", id, ratingList,
+        countries, countryStatus.name());
   }
 }

--- a/src/test/java/uk/gov/bis/lite/ogel/spire/ParseOgelTypeTest.java
+++ b/src/test/java/uk/gov/bis/lite/ogel/spire/ParseOgelTypeTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import uk.gov.bis.lite.ogel.model.OgelCondition;
+import uk.gov.bis.lite.ogel.model.Rating;
 import uk.gov.bis.lite.ogel.model.SpireOgel;
 import uk.gov.bis.lite.ogel.spire.parsers.OgelTypeParser;
 
@@ -48,11 +49,24 @@ public class ParseOgelTypeTest extends SpireParseTest {
   @Test
   public void testRatings() {
     assertThat(ogels).filteredOn("id", A1).extracting(SpireOgel::getOgelConditions)
-        .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getRatingList).asList().hasSize(3);
+        .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getRatingList).asList().hasSize(2);
     assertThat(ogels).filteredOn("id", A2).extracting(SpireOgel::getOgelConditions)
-        .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getRatingList).asList().hasSize(4);
+        .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getRatingList).asList().hasSize(3);
     assertThat(ogels).filteredOn("id", A3).extracting(SpireOgel::getOgelConditions)
-        .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getRatingList).asList().hasSize(5);
+        .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getRatingList).asList().hasSize(4);
+  }
+
+  @Test
+  public void excludedRatingsAreExcludedFromRatingsList() {
+    assertOgelConditionDoesNotContainRating(A1, "RATING2");
+    assertOgelConditionDoesNotContainRating(A2, "RATING5");
+    assertOgelConditionDoesNotContainRating(A3, "RATING8");
+  }
+
+  private void assertOgelConditionDoesNotContainRating(String ogelId, String rating) {
+    assertThat(ogels).filteredOn("id", ogelId).extracting(SpireOgel::getOgelConditions)
+        .extracting(conditions -> conditions.get(0)).flatExtracting(OgelCondition::getRatingList)
+        .extracting(Rating::getRatingCode).doesNotContain(rating);
   }
 
   @Test
@@ -78,9 +92,5 @@ public class ParseOgelTypeTest extends SpireParseTest {
         .extracting(cons -> cons.get(0)).extracting("countryStatus").hasToString(EXCLUDED);
     assertThat(ogels).filteredOn("id", A3).extracting(SpireOgel::getOgelConditions)
         .extracting(cons -> cons.get(0)).flatExtracting(OgelCondition::getCountries).asList().hasSize(5);
-
   }
-
 }
-
-


### PR DESCRIPTION
- excluding ratings on exclusion list from rating list
- added unit test for ^
- refactored to remove dead code (YAGNI)